### PR TITLE
docs: specify array indexing start and syntax more explicitly

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -72,9 +72,9 @@ hanna: {
 }
 ```
 
-As of specification version 1.4, it also now possible to reference values in arrays by index. You
-can do this by using the familiar syntax you use in other languages, an example of this usage can be
-seen below using this functionality.
+As of specification version 1.4, it also now possible to reference values in arrays by index.
+Indexing can be done with the common syntax: a non-negative integer enclosed by square brackets.
+Array indices start at 0. An example using this functionality can be seen below.
 
 ```
 defaults: {


### PR DESCRIPTION
I wrote `non-negative integer` but am not sure that is the intended behavior. Are negative indices allowed?
Perhaps it should also be clarified if the index can be written using the binary/octal/hex literal syntax.
Additionally, should references be allowed as indices? (maybe this should last point should be a separate PR) 